### PR TITLE
Add employee tenure display

### DIFF
--- a/_scripts/data.js
+++ b/_scripts/data.js
@@ -160,3 +160,19 @@ exports.salaryFields = salaryFields;
 exports.metrics_ext = metrics_ext;
 exports.colorize = colorize;
 exports.colorizeGradient = colorizeGradient;
+
+// Подсчет стажа работы в формате "N г. M мес." по дате найма
+function calcTenure(hireDate) {
+    if (!hireDate) return "";
+    const start = new Date(hireDate);
+    if (isNaN(start.getTime())) return "";
+    const today = new Date();
+    const monthsTotal = (today.getFullYear() - start.getFullYear()) * 12 +
+                        (today.getMonth() - start.getMonth());
+    if (monthsTotal < 0) return "";
+    const years = Math.floor(monthsTotal / 12);
+    const months = monthsTotal % 12;
+    return `${years > 0 ? years + " г. " : ""}${months} мес.`;
+}
+
+exports.calcTenure = calcTenure;

--- a/_views/employee-card/view.js
+++ b/_views/employee-card/view.js
@@ -1,4 +1,13 @@
-input.dv.header(1, "Зарплата, должность и связанные запросы")
+const data = require(app.vault.adapter.basePath + "/_scripts/data.js");
+
+// Стаж сотрудника сразу вверху страницы
+const hireDate = input.dv.current()["Принят"];
+const tenure = data.calcTenure(hireDate);
+if (tenure) {
+    input.dv.paragraph(`**Стаж:** ${tenure}`);
+}
+
+input.dv.header(1, "Зарплата, должность и связанные запросы");
 await input.dv.view("views/employee-salary-report", {"dv": input.dv});
 
 await input.dv.header(1, "Метрики");

--- a/_views/salary-summary-report/view.js
+++ b/_views/salary-summary-report/view.js
@@ -21,6 +21,7 @@ function findLastField(records, key) {
 for (const emp of employeePages) {
     const empLink = emp.file.link;
     const records = data.GetRawMetricsData(input.dv, empLink);
+    const tenure = data.calcTenure(emp["Принят"]);
 
     // Ищем последнее значение для ЗП и запроса
     const salaryObj = findLastField(records, "Зарплата");
@@ -32,6 +33,7 @@ for (const emp of employeePages) {
     allResults.push({
         name: emp.file.name,
         link: empLink,
+        tenure,
         salary: salaryObj ? salaryObj.value : "",
         salaryFile: salaryObj ? salaryObj.file : null,
         increase: increaseObj ? increaseObj.value : "",
@@ -61,6 +63,7 @@ function fileLinkCell(value, file) {
 // Собираем финальную таблицу
 const rows = allResults.sort((a, b) => !b.name.localeCompare(a.name)).map(res => [
     input.dv.span(`[[${res.name}]]`),
+    res.tenure || "",
     fileLinkCell(res.salary, res.salaryFile),
     fileLinkCell(res.increase, res.increaseFile),
     res.increaseComment || "",
@@ -75,12 +78,14 @@ const increasesOrSalaries = allResults.map(r => (r.increase && r.increase !== ""
 rows.push(
     [
         "**СУММА**",
+        "",
         salaries.length ? sum(salaries) : "",
         increasesOrSalaries.length ? sum(increasesOrSalaries) : "",
         "",
     ],
     [
         "**МЕДИАННА**",
+        "",
         salaries.length ? median(salaries) : "",
         increasesOrSalaries.length ? median(increasesOrSalaries) : "",
         "",
@@ -90,6 +95,6 @@ rows.push(
 input.dv.header(2, "Сводная таблица зарплат и запросов сотрудников");
 
 input.dv.table(
-    ["Cотрудник", "Текущая ЗП", "Запрос на ЗП", "Комментарий к запросу"],
+    ["Cотрудник", "Стаж", "Текущая ЗП", "Запрос на ЗП", "Комментарий к запросу"],
     rows
 );


### PR DESCRIPTION
## Summary
- show tenure at top of employee card
- reuse new `calcTenure` helper
- list tenure in global salary table

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685453ec14fc8332a581e7ecb77f7c36