### PR TITLE
Add feedback and fix plain Markdown export

### DIFF
--- a/_scripts/markdown-utils.js
+++ b/_scripts/markdown-utils.js
@@ -1,0 +1,75 @@
+function stripLinks(text) {
+    return String(text).replace(/\[\[([^\]]+)\]\]/g, (_, inner) => {
+        const i = inner.indexOf("|");
+        return i >= 0 ? inner.slice(i + 1) : inner;
+    });
+}
+
+function stripTags(text) {
+    return String(text).replace(/<[^>]*>/g, "");
+}
+
+function plainify(value) {
+    if (value && typeof value === "object") {
+        if ("textContent" in value) {
+            value = value.textContent;
+        } else {
+            value = String(value);
+        }
+    }
+    return stripTags(stripLinks(value));
+}
+
+function createMarkdownControls(opts) {
+    const controls = document.createElement("div");
+
+    const exportBtn = document.createElement("button");
+    exportBtn.textContent = "💾 Скачать таблицу как маркдаун файл";
+    exportBtn.style.marginRight = "6px";
+    controls.appendChild(exportBtn);
+
+    const copyBtn = document.createElement("button");
+    copyBtn.textContent = "📋 Скопировать таблица как маркдаун";
+    controls.appendChild(copyBtn);
+
+    exportBtn.addEventListener("click", () => {
+        const link = document.createElement("a");
+        link.href =
+            "data:text/markdown;charset=utf-8," +
+            encodeURIComponent(opts.getMarkdown());
+        link.download = opts.fileName;
+        link.style.display = "none";
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        const original = exportBtn.textContent;
+        exportBtn.textContent = "✅ Скачано!";
+        exportBtn.disabled = true;
+        setTimeout(() => {
+            exportBtn.textContent = original;
+            exportBtn.disabled = false;
+        }, 1000);
+    });
+
+    copyBtn.addEventListener("click", async () => {
+        try {
+            await navigator.clipboard.writeText(opts.getMarkdown());
+            const original = copyBtn.textContent;
+            copyBtn.textContent = "✅ Скопировано!";
+            copyBtn.disabled = true;
+            setTimeout(() => {
+                copyBtn.textContent = original;
+                copyBtn.disabled = false;
+            }, 1000);
+        } catch (e) {
+            console.error("Copy failed", e);
+        }
+    });
+
+    return controls;
+}
+
+exports.stripLinks = stripLinks;
+exports.stripTags = stripTags;
+exports.plainify = plainify;
+exports.createMarkdownControls = createMarkdownControls;

--- a/_views/global-metrics-summary-report/view.js
+++ b/_views/global-metrics-summary-report/view.js
@@ -87,6 +87,23 @@ input.dv.paragraph("Значения разбиты на группы задач
 
 await input.dv.table(headers, tableRows);
 
+
+const utils = require(app.vault.adapter.basePath + "/_scripts/markdown-utils.js");
+
+const getMarkdown = () => {
+    const h = headers.map(utils.plainify);
+    const rows = tableRows.map(r => r.map(utils.plainify));
+    return dv.markdownTable(h, rows);
+};
+
+input.dv.el(
+    "div",
+    utils.createMarkdownControls({
+        getMarkdown,
+        fileName: "global-metrics.md"
+    })
+);
+
 const tables  = container.querySelectorAll(".table-view-table");
  const lastTable = tables[tables.length - 1];
   if (lastTable) {

--- a/_views/salary-summary-report/view.js
+++ b/_views/salary-summary-report/view.js
@@ -90,3 +90,26 @@ input.dv.table(
     ["Cотрудник", "Текущая ЗП", "Запрос на ЗП", "Стаж", "Комментарий к запросу"],
     rows
 );
+
+const utils = require(app.vault.adapter.basePath + "/_scripts/markdown-utils.js");
+
+const getMarkdown = () => {
+    const h = [
+        "Cотрудник",
+        "Текущая ЗП",
+        "Запрос на ЗП",
+        "Стаж",
+        "Комментарий к запросу",
+    ];
+    const headers = h.map(utils.plainify);
+    const rowsPlain = rows.map(r => r.map(utils.plainify));
+    return dv.markdownTable(headers, rowsPlain);
+};
+
+input.dv.el(
+    "div",
+    utils.createMarkdownControls({
+        getMarkdown,
+        fileName: "salary-summary.md",
+    })
+);


### PR DESCRIPTION
## Summary
- handle DOM nodes when stripping table values
- show short confirmation messages for export and copy buttons
- extract shared helpers for Markdown export

## Testing
- `node --check _views/global-metrics-summary-report/view.js`
- `node --check _views/salary-summary-report/view.js`
- `node --check _scripts/markdown-utils.js`
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6855999cff6c8332a715c740a224b96f