### PR TITLE
Add last raise info to salary summary

### DIFF
--- a/_scripts/data.js
+++ b/_scripts/data.js
@@ -175,6 +175,38 @@ exports.metrics_ext = metrics_ext;
 exports.colorize = colorize;
 exports.colorizeGradient = colorizeGradient;
 exports.findLastValueAndFile = findLastValueAndFile;
+exports.findLastSalaryIncrease = findLastSalaryIncrease;
+
+// Определить дату и размер последнего повышения ЗП
+function findLastSalaryIncrease(records, key = "Зарплата") {
+    const latest = findLastValueAndFile(records, key);
+    if (!latest) return null;
+
+    let idx = records.findIndex(
+        r => r.page.path === latest.file.path && r.date.valueOf() === latest.date.valueOf()
+    );
+    idx = idx < 0 ? 0 : idx + 1;
+
+    let currentValue = parseFloat(latest.value);
+    let currentDate = latest.date;
+    let currentFile = latest.file;
+
+    for (let i = idx; i < records.length; i++) {
+        const rec = records[i];
+        const valRaw = rec.props[key];
+        if (valRaw === undefined || valRaw === "") continue;
+        const val = parseFloat(valRaw);
+        if (isNaN(val)) continue;
+        if (val < currentValue) {
+            return { amount: currentValue - val, date: currentDate, file: currentFile };
+        } else if (val > currentValue) {
+            currentValue = val;
+            currentDate = rec.date;
+            currentFile = rec.page;
+        }
+    }
+    return null;
+}
 
 // Подсчет стажа работы в формате "N г. M мес." по дате найма
 function calcTenure(hireDate) {

--- a/_views/salary-summary-report/view.js
+++ b/_views/salary-summary-report/view.js
@@ -19,6 +19,7 @@ for (const emp of employeePages) {
     const increaseObj = data.findLastValueAndFile(records, "Запрос на повышение");
     const increaseCommentObj = data.findLastValueAndFile(records, "Запрос на повышение - комментарий");
     const salaryCommentObj = data.findLastValueAndFile(records, "Зарплата - комментарий");
+    const lastRaise = data.findLastSalaryIncrease(records);
 
     // Формируем строку
     allResults.push({
@@ -30,6 +31,9 @@ for (const emp of employeePages) {
         increase: increaseObj ? increaseObj.value : "",
         increaseFile: increaseObj ? increaseObj.file : null,
         increaseComment: increaseCommentObj ? increaseCommentObj.value : (salaryCommentObj ? salaryCommentObj.value : ""),
+        lastRaiseAmount: lastRaise ? lastRaise.amount : "",
+        lastRaiseDate: lastRaise ? lastRaise.date.toISODate() : "",
+        lastRaiseFile: lastRaise ? lastRaise.file : null,
     });
 }
 
@@ -56,6 +60,8 @@ const rows = allResults.sort((a, b) => !b.name.localeCompare(a.name)).map(res =>
     input.dv.span(`[[${res.name}]]`),
     fileLinkCell(res.salary, res.salaryFile),
     fileLinkCell(res.increase, res.increaseFile),
+    fileLinkCell(res.lastRaiseDate, res.lastRaiseFile),
+    fileLinkCell(res.lastRaiseAmount, res.lastRaiseFile),
     res.tenure || "",
     res.increaseComment || "",
 ]);
@@ -73,12 +79,16 @@ rows.push(
         salaries.length ? sum(salaries) : "",
         increasesOrSalaries.length ? sum(increasesOrSalaries) : "",
         "",
+        "",
+        "",
     ],
     [
         "**МЕДИАННА**",
         "",
         salaries.length ? median(salaries) : "",
         increasesOrSalaries.length ? median(increasesOrSalaries) : "",
+        "",
+        "",
         "",
     ]
 );
@@ -87,7 +97,15 @@ rows.push(
 input.dv.header(2, "Сводная таблица зарплат и запросов сотрудников");
 
 input.dv.table(
-    ["Cотрудник", "Текущая ЗП", "Запрос на ЗП", "Стаж", "Комментарий к запросу"],
+    [
+        "Cотрудник",
+        "Текущая ЗП",
+        "Запрос на ЗП",
+        "Дата повышения",
+        "Сумма повышения",
+        "Стаж",
+        "Комментарий к запросу"
+    ],
     rows
 );
 
@@ -98,6 +116,8 @@ const getMarkdown = () => {
         "Cотрудник",
         "Текущая ЗП",
         "Запрос на ЗП",
+        "Дата повышения",
+        "Сумма повышения",
         "Стаж",
         "Комментарий к запросу",
     ];


### PR DESCRIPTION
## Summary
- extend helper to fetch latest raise data via `findLastSalaryIncrease`
- expose last raise date and amount columns in the salary summary report
- keep values clickable and linked to the source file

## Testing
- `node -e "require('./_scripts/data.js')"`
- `node -e "require('./_views/salary-summary-report/view.js')"` *(fails: app is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6855b50cd01c8332942cc44a1e1117cf